### PR TITLE
.travis.yml syntax error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install django splinter pygments misaka psycopg2 --use-mirrors
 
-before_script
+before_script:
  - cd djangoproject 
  - mv frespo/env_settings.py_template frespo/env_settings.py 
  - mkdir logs


### PR DESCRIPTION
You forgot a colon, so your YAML is invalid. The default travis behaviour is run as a ruby project.

Use http://yaml-online-parser.appspot.com/ or http://lint.travis-ci.org/ to check the YAML syntax.
