### PR TITLE
Simplify database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Instructions to run application locally:
 4. Create a Postgres user and database:
 
   ```bash
-  createuser -d -SR frespo
-  createdb -O frespo frespo
+  createdb -O postgres frespo
   ````
 
   You need to use `sudo -u postgres` to run these commands if you don't

--- a/djangoproject/frespo/env_settings.py_template
+++ b/djangoproject/frespo/env_settings.py_template
@@ -18,7 +18,7 @@ FAKE_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 ENVIRONMENT = 'NOT_DEV' #change to DEV in your machine
 
 DATABASE_NAME = 'frespo'
-DATABASE_USER = 'frespo'
+DATABASE_USER = 'postgres'
 DATABASE_PASS = ''
 
 GITHUB_BOT_USERNAME = 'freedomsponsors-bot'


### PR DESCRIPTION
The current database setup process is complicated.

It uses a _custom_ `migration` script after `syncdb`. I couldn't figure out why having this script specifying migration order.

Also if you run a plain `syncdb` and create a superuser the process will crash due to some strange dependecy to the `emailmgr` app  whose tables are created on migrations. This is the origin of the problem described on the issue #53.

The solution is to run syncdb and migrate, forcing not to create a superuser, on a single command line.
