### PR TITLE
Show status=EXPIRED to expired offers instead of OPEN

### DIFF
--- a/djangoproject/templates/core/issue.html
+++ b/djangoproject/templates/core/issue.html
@@ -67,7 +67,7 @@
           <i class="icon-gift popopo" rel="popover" data-content="Solution must be available as a new released version. Just commiting is not enough." data-original-title="Release required"></i>
         {% endif %}
       </td>
-      <td>{{offer.status}}</td>
+      <td>{% if offer.is_expired %}EXPIRED{% else %}{{offer.status}}{% endif %}</td>
       <td><span title="{{ offer.creationDate }}">{{ offer.creationDate|date:"M/d/Y" }}</span></td>
       <td>
         {% if offer.is_expired %}

--- a/djangoproject/templates/core/offer.html
+++ b/djangoproject/templates/core/offer.html
@@ -34,7 +34,7 @@
 {% if offer.issue.project %}
  | Project: <a target="_project" href="{{offer.issue.project.homeURL}}">{{offer.issue.project.name}}</a>
 {% endif %}
- | Status: {{offer.status}}
+ | Status: {% if offer.is_expired %}EXPIRED{% else %}{{offer.status}}{% endif %}
 {% if offer.issue.description %}
 <br><br>
 <h3>Issue Description</h3>


### PR DESCRIPTION
I'm not sure if you have a reason to maintain offer OPEN when it is expired, but it is a confusing (related with #93).
