### PR TITLE
Statistics refactory

### DIFF
--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -12,7 +12,7 @@ def get_offer_stats():
         sponsor_count=Count('sponsor', distinct=True),
         offer_count=Count('pk'),
         paid_offer_count=Count('pk', only=Q(status=Offer.PAID)),
-        open_offer_count=Count('pk', only=Q(status=Offer.OPEN)), # FIXME: Should OPEN ignore EXPIRED?
+        open_offer_count=Count('pk', only=Q(status=Offer.OPEN)),
         revoked_offer_count=Count('pk', only=Q(status=Offer.REVOKED)),
         paid_sum=Sum('price', only=Q(status=Offer.PAID)),
         open_sum=Sum('price', only=Q(status=Offer.OPEN) & (Q(expirationDate=None) | Q(expirationDate__gt=date.today()))),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,7 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_OFFERS = "select count(*) from core_offer"
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
@@ -34,7 +33,7 @@ def get_stats():
         'sponsor_count' : Offer.objects.aggregate(Count('sponsor', distinct=True))['sponsor__count'] or 0,
         'programmer_count' : Solution.objects.aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
         'paid_programmer_count' : PaymentPart.objects.filter(payment__status='CONFIRMED_IPN').aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
-        'offer_count' : _count(COUNT_OFFERS),
+        'offer_count' : Offer.objects.count(),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),
         'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],
         'issue_count_kickstarting' : Issue.objects.filter(is_feedback=False, is_public_suggestion=True).count(),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -33,7 +33,6 @@ and pa.status = 'CONFIRMED_IPN'"""
 
 COUNT_OFFERS = "select count(*) from core_offer"
 COUNT_ISSUES_SPONSORING = "select count(*) from core_issue where is_feedback = false and is_public_suggestion = false"
-COUNT_ISSUES_KICKSTARTING = "select count(*) from core_issue where is_feedback = false and is_public_suggestion = true"
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
@@ -56,10 +55,10 @@ def get_stats():
         'programmer_count' : _count(COUNT_PROGRAMMERS),
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),
-        'issue_count_kickstarting' : _count(COUNT_ISSUES_KICKSTARTING),
         'issue_count_sponsoring' : _count(COUNT_ISSUES_SPONSORING),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),
         'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],
+        'issue_count_kickstarting' : Issue.objects.filter(is_feedback=False, is_public_suggestion=True).count(),
         'paid_offer_count' : _count(COUNT_OFFERS_PAID),
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,7 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
 
@@ -38,7 +37,7 @@ def get_stats():
         'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],
         'issue_count_kickstarting' : Issue.objects.filter(is_feedback=False, is_public_suggestion=True).count(),
         'issue_count_sponsoring' : Issue.objects.filter(is_feedback=False, is_public_suggestion=False).count(),
-        'paid_offer_count' : _count(COUNT_OFFERS_PAID),
+        'paid_offer_count' : Offer.objects.filter(status=Offer.PAID).count(),
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),
         'paid_sum' : _sum(SUM_PAID),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -31,7 +31,6 @@ where pr.payment_id = pa.id
 and pa.status = 'CONFIRMED_IPN'"""
 
 COUNT_OFFERS = "select count(*) from core_offer"
-COUNT_ISSUES = "select count(*) from core_issue where is_feedback = false"
 COUNT_ISSUES_SPONSORING = "select count(*) from core_issue where is_feedback = false and is_public_suggestion = false"
 COUNT_ISSUES_KICKSTARTING = "select count(*) from core_issue where is_feedback = false and is_public_suggestion = true"
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
@@ -57,10 +56,10 @@ def get_stats():
         'programmer_count' : _count(COUNT_PROGRAMMERS),
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),
-        'issue_count' : _count(COUNT_ISSUES),
         'issue_project_count' : _count(COUNT_PROJECTS),
         'issue_count_kickstarting' : _count(COUNT_ISSUES_KICKSTARTING),
         'issue_count_sponsoring' : _count(COUNT_ISSUES_SPONSORING),
+        'issue_count' : Issue.objects.filter(is_feedback=False).count(),
         'paid_offer_count' : _count(COUNT_OFFERS_PAID),
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -42,7 +42,6 @@ COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'
 SUM_PAID = "select sum (price) from core_offer where status = 'PAID'"
 
 
-SUM_EXPIRED = """select sum (price) from core_offer where status = 'OPEN' and "expirationDate" <= now()"""
 
 SUM_REVOKED = "select sum (price) from core_offer where status = 'REVOKED'"
 
@@ -64,8 +63,8 @@ def get_stats():
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),
         'paid_sum' : _sum(SUM_PAID),
-        'expired_sum' : _sum(SUM_EXPIRED),
         'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
+        'expired_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'revoked_sum' : _sum(SUM_REVOKED),
         'sponsors' : _select(SELECT_SPONSORS),
         'projects' : _select(SELECT_SPONSORED_PROJECTS),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timedelta
-import math
+from datetime import datetime
 from core.models import *
-from django.db import connection, transaction
 from django.db.models import Q
 from django.db.models import Count
 from django.utils.datetime_safe import date
@@ -46,19 +44,3 @@ def _age():
         if(weeks > 1):
             s += "s"
     return s;
-
-def _count(query):
-    return int(_sum(query))
-
-def _sum(query):
-    rows = _select(query)
-    r = rows[0][0]
-    if r is None:
-        r = 0
-    return r
-
-def _select(query):
-    cursor = connection.cursor()
-    cursor.execute(query)
-    rows = cursor.fetchall()
-    return rows

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import math
 from core.models import *
 from django.db import connection, transaction
+from django.db.models import Count
 
 SELECT_SPONSORS = """select t.user_id, t."screenName", sum(p1), sum(p2), coalesce(sum(p1), 0) + coalesce(sum(p2), 0) as s3
 from (select o.id, ui.user_id, ui."screenName", o.price as p1, null as p2
@@ -36,7 +37,6 @@ COUNT_ISSUES_KICKSTARTING = "select count(*) from core_issue where is_feedback =
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
-COUNT_PROJECTS = "select count(distinct project_id) from core_issue where is_feedback = false"
 
 SUM_PAID = "select sum (price) from core_offer where status = 'PAID'"
 
@@ -56,10 +56,10 @@ def get_stats():
         'programmer_count' : _count(COUNT_PROGRAMMERS),
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),
-        'issue_project_count' : _count(COUNT_PROJECTS),
         'issue_count_kickstarting' : _count(COUNT_ISSUES_KICKSTARTING),
         'issue_count_sponsoring' : _count(COUNT_ISSUES_SPONSORING),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),
+        'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],
         'paid_offer_count' : _count(COUNT_OFFERS_PAID),
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,10 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-SUM_PAID = "select sum (price) from core_offer where status = 'PAID'"
-
-
-
 SUM_REVOKED = "select sum (price) from core_offer where status = 'REVOKED'"
 
 LAUNCH_DATE = datetime(2012, 7, 8)
@@ -37,7 +33,7 @@ def get_stats():
         'paid_offer_count' : Offer.objects.filter(status=Offer.PAID).count(),
         'open_offer_count' : Offer.objects.filter(status=Offer.OPEN).count(),
         'revoked_offer_count' : Offer.objects.filter(status=Offer.REVOKED).count(),
-        'paid_sum' : _sum(SUM_PAID),
+        'paid_sum' : Offer.objects.filter(status=Offer.PAID).aggregate(Sum('price'))['price__sum'] or 0,
         'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'expired_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'revoked_sum' : _sum(SUM_REVOKED),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,7 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
 
 SUM_PAID = "select sum (price) from core_offer where status = 'PAID'"
@@ -38,7 +37,7 @@ def get_stats():
         'issue_count_kickstarting' : Issue.objects.filter(is_feedback=False, is_public_suggestion=True).count(),
         'issue_count_sponsoring' : Issue.objects.filter(is_feedback=False, is_public_suggestion=False).count(),
         'paid_offer_count' : Offer.objects.filter(status=Offer.PAID).count(),
-        'open_offer_count' : _count(COUNT_OFFERS_OPEN),
+        'open_offer_count' : Offer.objects.filter(status=Offer.OPEN).count(),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),
         'paid_sum' : _sum(SUM_PAID),
         'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,7 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_SPONSORS = "select count(distinct sponsor_id) from core_offer"
 COUNT_PROGRAMMERS = "select count(distinct programmer_id) from core_solution"
 COUNT_PAID_PROGRAMMERS = """select count(distinct pr.programmer_id) 
 from core_paymentpart pr, core_payment pa
@@ -38,7 +37,7 @@ def get_stats():
     return {
         'age' : _age(),
         'user_count' : UserInfo.objects.count(),
-        'sponsor_count' : _count(COUNT_SPONSORS),
+        'sponsor_count' : Offer.objects.aggregate(Count('sponsor', distinct=True))['sponsor__count'] or 0,
         'programmer_count' : _count(COUNT_PROGRAMMERS),
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -35,9 +35,9 @@ def get_stats():
         'programmer_count' : Solution.objects.aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
         'paid_programmer_count' : PaymentPart.objects.filter(payment__status='CONFIRMED_IPN').aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
         'sponsors' : UserInfo.objects.annotate(
-                         paid_ammount=Sum('user__offer__price', only=Q(user__offer__status=Offer.PAID)),
-                         open_ammount=Sum('user__offer__price', only=Q(user__offer__status=Offer.OPEN)),
-                     ).order_by('-paid_ammount'),
+                         paid_amount=Sum('user__offer__price', only=Q(user__offer__status=Offer.PAID)),
+                         open_amount=Sum('user__offer__price', only=Q(user__offer__status=Offer.OPEN)),
+                     ).order_by('-paid_amount'),
         'projects' : Project.objects.annotate(issue_count=Count('issue', distinct=True), offer_sum=Sum('issue__offer__price')).order_by('-offer_sum'),
     }
 

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -24,12 +24,12 @@ def get_stats():
         'open_offer_count' : Offer.objects.filter(status=Offer.OPEN).count(),
         'revoked_offer_count' : Offer.objects.filter(status=Offer.REVOKED).count(),
         'paid_sum' : Offer.objects.filter(status=Offer.PAID).aggregate(Sum('price'))['price__sum'] or 0,
-        'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
-        'expired_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
+        'open_sum' : Offer.objects.filter(status=Offer.OPEN).filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
+        'expired_sum' : Offer.objects.filter(status=Offer.OPEN).filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'revoked_sum' : Offer.objects.filter(status=Offer.REVOKED).aggregate(Sum('price'))['price__sum'] or 0,
         'sponsors' : UserInfo.objects.annotate(
-                         paid_ammount=Sum('user__offer__price', only=Q(user__offer__status='PAID')),
-                         open_ammount=Sum('user__offer__price', only=Q(user__offer__status='OPEN')),
+                         paid_ammount=Sum('user__offer__price', only=Q(user__offer__status=Offer.PAID)),
+                         open_ammount=Sum('user__offer__price', only=Q(user__offer__status=Offer.OPEN)),
                      ).order_by('-paid_ammount'),
         'projects' : Project.objects.annotate(issue_count=Count('issue', distinct=True), offer_sum=Sum('issue__offer__price')).order_by('-offer_sum'),
     }

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,11 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_PAID_PROGRAMMERS = """select count(distinct pr.programmer_id) 
-from core_paymentpart pr, core_payment pa
-where pr.payment_id = pa.id
-and pa.status = 'CONFIRMED_IPN'"""
-
 COUNT_OFFERS = "select count(*) from core_offer"
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
@@ -38,7 +33,7 @@ def get_stats():
         'user_count' : UserInfo.objects.count(),
         'sponsor_count' : Offer.objects.aggregate(Count('sponsor', distinct=True))['sponsor__count'] or 0,
         'programmer_count' : Solution.objects.aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
-        'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
+        'paid_programmer_count' : PaymentPart.objects.filter(payment__status='CONFIRMED_IPN').aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
         'offer_count' : _count(COUNT_OFFERS),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),
         'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,7 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_PROGRAMMERS = "select count(distinct programmer_id) from core_solution"
 COUNT_PAID_PROGRAMMERS = """select count(distinct pr.programmer_id) 
 from core_paymentpart pr, core_payment pa
 where pr.payment_id = pa.id
@@ -38,7 +37,7 @@ def get_stats():
         'age' : _age(),
         'user_count' : UserInfo.objects.count(),
         'sponsor_count' : Offer.objects.aggregate(Count('sponsor', distinct=True))['sponsor__count'] or 0,
-        'programmer_count' : _count(COUNT_PROGRAMMERS),
+        'programmer_count' : Solution.objects.aggregate(Count('programmer', distinct=True))['programmer__count'] or 0,
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -1,21 +1,19 @@
 from datetime import datetime
 from core.models import *
 from django.db.models import Q
-from django.db.models import Count
 from django.utils.datetime_safe import date
-from aggregate_if import Sum
-from aggregate_if import Count as CountIf
+from aggregate_if import Sum, Count
 
 
 LAUNCH_DATE = datetime(2012, 7, 8)
 
 def get_offer_stats():
     return Offer.objects.aggregate(
-        sponsor_count=CountIf('sponsor'), #, distinct=True),
-        offer_count=CountIf('pk'), #, distinct=True),
-        paid_offer_count=CountIf('pk', only=Q(status=Offer.PAID)),
-        open_offer_count=CountIf('pk', only=Q(status=Offer.OPEN)), # FIXME: Should OPEN ignore EXPIRED?
-        revoked_offer_count=CountIf('pk', only=Q(status=Offer.REVOKED)),
+        sponsor_count=Count('sponsor', distinct=True),
+        offer_count=Count('pk'),
+        paid_offer_count=Count('pk', only=Q(status=Offer.PAID)),
+        open_offer_count=Count('pk', only=Q(status=Offer.OPEN)), # FIXME: Should OPEN ignore EXPIRED?
+        revoked_offer_count=Count('pk', only=Q(status=Offer.REVOKED)),
         paid_sum=Sum('price', only=Q(status=Offer.PAID)),
         open_sum=Sum('price', only=Q(status=Offer.OPEN) & (Q(expirationDate=None) | Q(expirationDate__gt=date.today()))),
         expired_sum=Sum('price', only=Q(status=Offer.OPEN) & Q(expirationDate__lte=date.today())),
@@ -26,8 +24,8 @@ def get_issue_stats():
     return Issue.objects.filter(is_feedback=False).aggregate(
         issue_count=Count('pk'),
         issue_project_count=Count('project', distinct=True),
-        issue_count_kickstarting=CountIf('pk', only=Q(is_public_suggestion=True)),
-        issue_count_sponsoring=CountIf('pk', only=Q(is_public_suggestion=False)),
+        issue_count_kickstarting=Count('pk', only=Q(is_public_suggestion=True)),
+        issue_count_sponsoring=Count('pk', only=Q(is_public_suggestion=False)),
     )
 
 def get_stats():

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -32,7 +32,6 @@ where pr.payment_id = pa.id
 and pa.status = 'CONFIRMED_IPN'"""
 
 COUNT_OFFERS = "select count(*) from core_offer"
-COUNT_ISSUES_SPONSORING = "select count(*) from core_issue where is_feedback = false and is_public_suggestion = false"
 COUNT_OFFERS_PAID = "select count(*) from core_offer where status = 'PAID'"
 COUNT_OFFERS_OPEN = "select count(*) from core_offer where status = 'OPEN'"
 COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
@@ -55,10 +54,10 @@ def get_stats():
         'programmer_count' : _count(COUNT_PROGRAMMERS),
         'paid_programmer_count' : _count(COUNT_PAID_PROGRAMMERS),
         'offer_count' : _count(COUNT_OFFERS),
-        'issue_count_sponsoring' : _count(COUNT_ISSUES_SPONSORING),
         'issue_count' : Issue.objects.filter(is_feedback=False).count(),
         'issue_project_count' : Issue.objects.filter(is_feedback=False).aggregate(Count('project', distinct=True))['project__count'],
         'issue_count_kickstarting' : Issue.objects.filter(is_feedback=False, is_public_suggestion=True).count(),
+        'issue_count_sponsoring' : Issue.objects.filter(is_feedback=False, is_public_suggestion=False).count(),
         'paid_offer_count' : _count(COUNT_OFFERS_PAID),
         'open_offer_count' : _count(COUNT_OFFERS_OPEN),
         'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,8 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-COUNT_OFFERS_REVOKED = "select count(*) from core_offer where status = 'REVOKED'"
-
 SUM_PAID = "select sum (price) from core_offer where status = 'PAID'"
 
 
@@ -38,7 +36,7 @@ def get_stats():
         'issue_count_sponsoring' : Issue.objects.filter(is_feedback=False, is_public_suggestion=False).count(),
         'paid_offer_count' : Offer.objects.filter(status=Offer.PAID).count(),
         'open_offer_count' : Offer.objects.filter(status=Offer.OPEN).count(),
-        'revoked_offer_count' : _count(COUNT_OFFERS_REVOKED),
+        'revoked_offer_count' : Offer.objects.filter(status=Offer.REVOKED).count(),
         'paid_sum' : _sum(SUM_PAID),
         'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'expired_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -14,8 +14,6 @@ where pr.id = i.project_id and i.id = o.issue_id
 group by pr.id, pr.name
 order by s desc"""
 
-SUM_REVOKED = "select sum (price) from core_offer where status = 'REVOKED'"
-
 LAUNCH_DATE = datetime(2012, 7, 8)
 
 def get_stats():
@@ -36,7 +34,7 @@ def get_stats():
         'paid_sum' : Offer.objects.filter(status=Offer.PAID).aggregate(Sum('price'))['price__sum'] or 0,
         'open_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate=None) | Q(expirationDate__gt=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
         'expired_sum' : Offer.objects.filter(status='OPEN').filter(Q(expirationDate__lte=date.today())).aggregate(Sum('price'))['price__sum'] or 0,
-        'revoked_sum' : _sum(SUM_REVOKED),
+        'revoked_sum' : Offer.objects.filter(status=Offer.REVOKED).aggregate(Sum('price'))['price__sum'] or 0,
         'sponsors' : UserInfo.objects.annotate(
                          paid_ammount=Sum('user__offer__price', only=Q(user__offer__status='PAID')),
                          open_ammount=Sum('user__offer__price', only=Q(user__offer__status='OPEN')),

--- a/djangoproject/core/services/stats_services.py
+++ b/djangoproject/core/services/stats_services.py
@@ -8,12 +8,6 @@ from django.utils.datetime_safe import date
 from aggregate_if import Sum
 
 
-SELECT_SPONSORED_PROJECTS = """select pr.id, pr.name, count(i.id) c, sum(o.price) s
-from core_project pr, core_issue i, core_offer o
-where pr.id = i.project_id and i.id = o.issue_id
-group by pr.id, pr.name
-order by s desc"""
-
 LAUNCH_DATE = datetime(2012, 7, 8)
 
 def get_stats():
@@ -39,7 +33,7 @@ def get_stats():
                          paid_ammount=Sum('user__offer__price', only=Q(user__offer__status='PAID')),
                          open_ammount=Sum('user__offer__price', only=Q(user__offer__status='OPEN')),
                      ).order_by('-paid_ammount'),
-        'projects' : _select(SELECT_SPONSORED_PROJECTS),
+        'projects' : Project.objects.annotate(issue_count=Count('issue', distinct=True), offer_sum=Sum('issue__offer__price')).order_by('-offer_sum'),
     }
 
 def _age():

--- a/djangoproject/core/tests/__init__.py
+++ b/djangoproject/core/tests/__init__.py
@@ -5,6 +5,7 @@ from test_payment_services import *
 from test_watch_services import *
 from test_watch_views import *
 from test_feedback_views import *
+from test_stats import *
 
 __author__ = 'tony'
 

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -3,12 +3,13 @@ from mock import patch, Mock
 from model_mommy import mommy
 from django.test import TestCase
 from django.utils.datetime_safe import date
+from django.core.urlresolvers import reverse as r
 from core.services import stats_services
 
 
 class StatsView(TestCase):
     def setUp(self):
-        self.resp = self.client.get('/core/stats/')
+        self.resp = self.client.get(r('stats'))
 
     def test_get(self):
         self.assertEqual(200, self.resp.status_code)
@@ -21,7 +22,7 @@ class StatsView(TestCase):
 
     def test_num_queries(self):
         with self.assertNumQueries(7):
-            self.client.get('/core/stats/')
+            self.client.get(r('stats'))
 
 
 class Sponsors(TestCase):

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -1,5 +1,7 @@
 # coding: utf-8
+from model_mommy import mommy
 from django.test import TestCase
+from core.services import stats_services
 
 
 class StatsView(TestCase):
@@ -14,4 +16,19 @@ class StatsView(TestCase):
 
     def test_context(self):
         self.assertIn('stats', self.resp.context)
+
+
+class StatsService(TestCase):
+    def setUp(self):
+        mommy.make_one('core.Project')
+
+        p = mommy.make_one('core.Project')
+        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=False)
+        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=False)
+        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=True)
+
+        self.stats = stats_services.get_stats()
+
+    def test_issue_project_count(self):
+        self.assertEqual(1, self.stats['issue_project_count'])
 

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -17,6 +17,10 @@ class StatsView(TestCase):
     def test_context(self):
         self.assertIn('stats', self.resp.context)
 
+    def test_num_queries(self):
+        with self.assertNumQueries(18):
+            self.client.get('/core/stats/')
+
 
 class CountProject(TestCase):
     def setUp(self):

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -24,50 +24,6 @@ class StatsView(TestCase):
             self.client.get('/core/stats/')
 
 
-class CountProject(TestCase):
-    def setUp(self):
-        mommy.make_one('core.Project')
-
-        p = mommy.make_one('core.Project')
-        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=False)
-        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=False)
-        mommy.make_one('core.Issue', project=p, createdByUser=p.createdByUser, is_feedback=True)
-
-        self.stats = stats_services.get_stats()
-
-    def test_count_project(self):
-        self.assertEqual(1, self.stats['issue_project_count'])
-
-
-class CountKickstarting(TestCase):
-    def setUp(self):
-        mommy.make_one('core.Issue', is_feedback=False, is_public_suggestion=False)
-        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=False)
-        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=True)
-
-        # Query hit
-        mommy.make_many('core.Issue', quantity=2, is_feedback=False, is_public_suggestion=True)
-
-        self.stats = stats_services.get_stats()
-
-    def test_count_kickstarting(self):
-        self.assertEqual(2, self.stats['issue_count_kickstarting'])
-
-class CountSponsoring(TestCase):
-    def setUp(self):
-        mommy.make_one('core.Issue', is_feedback=False, is_public_suggestion=True)
-        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=False)
-        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=True)
-
-        # Query hit
-        mommy.make_many('core.Issue', quantity=2, is_feedback=False, is_public_suggestion=False)
-
-        self.stats = stats_services.get_stats()
-
-    def test_count_sponsoring(self):
-        self.assertEqual(2, self.stats['issue_count_sponsoring'])
-
-
 class Sponsors(TestCase):
     def setUp(self):
         u = mommy.make_one('core.UserInfo', screenName='sponsorA')

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -160,3 +160,15 @@ class CountPaidProgrammers(TestCase):
 
     def test_count_paid_programmers(self):
         self.assertEqual(2, self.stats['paid_programmer_count'])
+
+
+class CountOffers(TestCase):
+    def setUp(self):
+        mommy.make_many('core.Offer', quantity=2, status='PAID')
+        mommy.make_many('core.Offer', quantity=2, status='OPEN')
+        mommy.make_many('core.Offer', quantity=2, status='REVOKED')
+        self.stats = stats_services.get_stats()
+
+    def test_count_offers(self):
+        self.assertEqual(6, self.stats['offer_count'])
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -175,3 +175,6 @@ class CountOffers(TestCase):
     def test_count_paid_offers(self):
         self.assertEqual(2, self.stats['paid_offer_count'])
 
+    def test_count_open_offers(self):
+        self.assertEqual(2, self.stats['open_offer_count'])
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -145,3 +145,18 @@ class CountProgrammersWithSolutions(TestCase):
 
     def test_count_programmers_with_solutions(self):
         self.assertEqual(2, self.stats['programmer_count'])
+
+
+class CountPaidProgrammers(TestCase):
+    def setUp(self):
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=1, payment__status='CONFIRMED_IPN')
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=2, payment__status='CONFIRMED_IPN')
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=1)
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=2)
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=3)
+        mommy.make_many('core.PaymentPart', quantity=2, programmer__id=4)
+
+        self.stats = stats_services.get_stats()
+
+    def test_count_paid_programmers(self):
+        self.assertEqual(2, self.stats['paid_programmer_count'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -47,4 +47,17 @@ class CountKickstarting(TestCase):
     def test_count_kickstarting(self):
         self.assertEqual(2, self.stats['issue_count_kickstarting'])
 
+class CountSponsoring(TestCase):
+    def setUp(self):
+        mommy.make_one('core.Issue', is_feedback=False, is_public_suggestion=True)
+        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=False)
+        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=True)
+
+        # Query hit
+        mommy.make_many('core.Issue', quantity=2, is_feedback=False, is_public_suggestion=False)
+
+        self.stats = stats_services.get_stats()
+
+    def test_count_sponsoring(self):
+        self.assertEqual(2, self.stats['issue_count_sponsoring'])
 

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -68,45 +68,6 @@ class CountSponsoring(TestCase):
         self.assertEqual(2, self.stats['issue_count_sponsoring'])
 
 
-class SumPriceOfOpenOffers(TestCase):
-    def setUp(self):
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=None)
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 12))
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 13))
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 01))
-        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=date(2012, 12, 01))
-        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=date(2012, 12, 12))
-        # Query hits
-        mommy.make_one('core.Offer', status='OPEN', price=9, expirationDate=None)
-        mommy.make_one('core.Offer', status='OPEN', price=90, expirationDate=date(2012, 12, 13))
-
-        with patch('django.utils.datetime_safe.date.today', Mock(return_value=date(2012, 12, 12))):
-            self.stats = stats_services.get_stats()
-
-    def test_sum_price_of_open_offers(self):
-        self.assertEqual(99, self.stats['open_sum'])
-
-
-class SumPriceOfExpiredOffers(TestCase):
-    def setUp(self):
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=None)
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 12))
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 13))
-        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 01))
-        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=None)
-        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=date(2012, 12, 13))
-
-        # Query hits
-        mommy.make_one('core.Offer', status='OPEN', price=9, expirationDate=date(2012, 12, 01))
-        mommy.make_one('core.Offer', status='OPEN', price=90, expirationDate=date(2012, 12, 12))
-
-        with patch('django.utils.datetime_safe.date.today', Mock(return_value=date(2012, 12, 12))):
-            self.stats = stats_services.get_stats()
-
-    def test_sum_price_of_expired_offers(self):
-        self.assertEqual(99, self.stats['expired_sum'])
-
-
 class Sponsors(TestCase):
     def setUp(self):
         u = mommy.make_one('core.UserInfo', screenName='sponsorA')
@@ -124,20 +85,6 @@ class Sponsors(TestCase):
         with self.assertNumQueries(1):
             for obj in self.stats['sponsors']:
                 pass
-
-
-
-class CountSponsors(TestCase):
-    def setUp(self):
-        u1 = mommy.make_one('auth.User')
-        u2 = mommy.make_one('auth.User')
-        mommy.make_many('core.Offer', quantity=2, sponsor=u1)
-        mommy.make_many('core.Offer', quantity=2, sponsor=u2)
-
-        self.stats = stats_services.get_stats()
-
-    def test_count_sponsors(self):
-        self.assertEqual(2, self.stats['sponsor_count'])
 
 
 class CountProgrammersWithSolutions(TestCase):
@@ -166,32 +113,6 @@ class CountPaidProgrammers(TestCase):
 
     def test_count_paid_programmers(self):
         self.assertEqual(2, self.stats['paid_programmer_count'])
-
-
-class CountOffers(TestCase):
-    def setUp(self):
-        mommy.make_many('core.Offer', quantity=2, price=1, status='PAID')
-        mommy.make_many('core.Offer', quantity=2, price=1, status='OPEN')
-        mommy.make_many('core.Offer', quantity=2, price=1, status='REVOKED')
-        self.stats = stats_services.get_stats()
-
-    def test_count_offers(self):
-        self.assertEqual(6, self.stats['offer_count'])
-
-    def test_count_paid_offers(self):
-        self.assertEqual(2, self.stats['paid_offer_count'])
-
-    def test_count_open_offers(self):
-        self.assertEqual(2, self.stats['open_offer_count'])
-
-    def test_count_revoked_offers(self):
-        self.assertEqual(2, self.stats['revoked_offer_count'])
-
-    def test_sum_paid_offers(self):
-        self.assertEqual(2, self.stats['paid_sum'])
-
-    def test_sum_revoked_offers(self):
-        self.assertEqual(2, self.stats['revoked_sum'])
 
 
 class Projects(TestCase):

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -106,3 +106,18 @@ class SumPriceOfExpiredOffers(TestCase):
     def test_sum_price_of_expired_offers(self):
         self.assertEqual(99, self.stats['expired_sum'])
 
+
+class Sponsors(TestCase):
+    def setUp(self):
+        u = mommy.make_one('core.UserInfo', screenName='sponsorA')
+        mommy.make_one('core.Offer', sponsor=u.user, price=10, status='PAID', expirationDate=None)
+        mommy.make_one('core.Offer', sponsor=u.user, price=90, status='OPEN', expirationDate=None)
+
+        self.stats = stats_services.get_stats()
+
+    def test_sponsors(self):
+        qs = self.stats['sponsors']
+        self.assertQuerysetEqual(qs, [('sponsorA', 10, 90)],
+                                 lambda u: (u.screenName, u.paid_ammount, u.open_ammount))
+
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -134,3 +134,14 @@ class CountSponsors(TestCase):
         self.assertEqual(2, self.stats['sponsor_count'])
 
 
+class CountProgrammersWithSolutions(TestCase):
+    def setUp(self):
+        u1 = mommy.make_one('auth.User')
+        u2 = mommy.make_one('auth.User')
+        mommy.make_many('core.Solution', quantity=2, programmer=u1)
+        mommy.make_many('core.Solution', quantity=2, programmer=u2)
+
+        self.stats = stats_services.get_stats()
+
+    def test_count_programmers_with_solutions(self):
+        self.assertEqual(2, self.stats['programmer_count'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -18,7 +18,7 @@ class StatsView(TestCase):
         self.assertIn('stats', self.resp.context)
 
 
-class StatsService(TestCase):
+class CountProject(TestCase):
     def setUp(self):
         mommy.make_one('core.Project')
 
@@ -29,7 +29,7 @@ class StatsService(TestCase):
 
         self.stats = stats_services.get_stats()
 
-    def test_issue_project_count(self):
+    def test_count_project(self):
         self.assertEqual(1, self.stats['issue_project_count'])
 
 

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -164,9 +164,9 @@ class CountPaidProgrammers(TestCase):
 
 class CountOffers(TestCase):
     def setUp(self):
-        mommy.make_many('core.Offer', quantity=2, status='PAID')
-        mommy.make_many('core.Offer', quantity=2, status='OPEN')
-        mommy.make_many('core.Offer', quantity=2, status='REVOKED')
+        mommy.make_many('core.Offer', quantity=2, price=1, status='PAID')
+        mommy.make_many('core.Offer', quantity=2, price=1, status='OPEN')
+        mommy.make_many('core.Offer', quantity=2, price=1, status='REVOKED')
         self.stats = stats_services.get_stats()
 
     def test_count_offers(self):
@@ -180,3 +180,6 @@ class CountOffers(TestCase):
 
     def test_count_revoked_offers(self):
         self.assertEqual(2, self.stats['revoked_offer_count'])
+
+    def test_sum_paid_offers(self):
+        self.assertEqual(2, self.stats['paid_sum'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -183,3 +183,6 @@ class CountOffers(TestCase):
 
     def test_sum_paid_offers(self):
         self.assertEqual(2, self.stats['paid_sum'])
+
+    def test_sum_revoked_offers(self):
+        self.assertEqual(2, self.stats['revoked_sum'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -1,1 +1,17 @@
 # coding: utf-8
+from django.test import TestCase
+
+
+class StatsView(TestCase):
+    def setUp(self):
+        self.resp = self.client.get('/core/stats/')
+
+    def test_get(self):
+        self.assertEqual(200, self.resp.status_code)
+
+    def test_template(self):
+        self.assertTemplateUsed(self.resp, 'core/stats.html')
+
+    def test_context(self):
+        self.assertIn('stats', self.resp.context)
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -35,7 +35,7 @@ class Sponsors(TestCase):
     def test_sponsors(self):
         qs = self.stats['sponsors']
         self.assertQuerysetEqual(qs, [('sponsorA', 10, 90)],
-                                 lambda u: (u.screenName, u.paid_ammount, u.open_ammount))
+                                 lambda u: (u.screenName, u.paid_amount, u.open_amount))
 
     def test_num_queries(self):
         with self.assertNumQueries(1):

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -32,3 +32,19 @@ class StatsService(TestCase):
     def test_issue_project_count(self):
         self.assertEqual(1, self.stats['issue_project_count'])
 
+
+class CountKickstarting(TestCase):
+    def setUp(self):
+        mommy.make_one('core.Issue', is_feedback=False, is_public_suggestion=False)
+        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=False)
+        mommy.make_one('core.Issue', is_feedback=True, is_public_suggestion=True)
+
+        # Query hit
+        mommy.make_many('core.Issue', quantity=2, is_feedback=False, is_public_suggestion=True)
+
+        self.stats = stats_services.get_stats()
+
+    def test_count_kickstarting(self):
+        self.assertEqual(2, self.stats['issue_count_kickstarting'])
+
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -20,7 +20,7 @@ class StatsView(TestCase):
         self.assertIn('stats', self.resp.context)
 
     def test_num_queries(self):
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(7):
             self.client.get('/core/stats/')
 
 
@@ -168,3 +168,25 @@ class OfferStats(TestCase):
 
     def test_revoked_sum(self):
         self.assertEqual(26, self.stats['revoked_sum'])
+
+
+class IssueStats(TestCase):
+    def setUp(self):
+        mommy.make_one('core.Issue', is_feedback=True, project__id=1)
+        mommy.make_one('core.Issue', is_feedback=False, project__id=2, is_public_suggestion=False)
+        mommy.make_one('core.Issue', is_feedback=False, project__id=2, is_public_suggestion=True)
+
+        with self.assertNumQueries(1):
+            self.stats = stats_services.get_issue_stats()
+
+    def test_issue_count(self):
+        self.assertEqual(2, self.stats['issue_count'])
+
+    def test_issue_project_count(self):
+        self.assertEqual(1, self.stats['issue_project_count'])
+
+    def test_issue_count_kickstarting(self):
+        self.assertEqual(1, self.stats['issue_count_kickstarting'])
+
+    def test_issue_count_sponsoring(self):
+        self.assertEqual(1, self.stats['issue_count_sponsoring'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -172,3 +172,6 @@ class CountOffers(TestCase):
     def test_count_offers(self):
         self.assertEqual(6, self.stats['offer_count'])
 
+    def test_count_paid_offers(self):
+        self.assertEqual(2, self.stats['paid_offer_count'])
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -186,3 +186,19 @@ class CountOffers(TestCase):
 
     def test_sum_revoked_offers(self):
         self.assertEqual(2, self.stats['revoked_sum'])
+
+
+class Projects(TestCase):
+    def setUp(self):
+        for i in mommy.make_many('core.Issue', quantity=3, project__id=1, project__name='projectA'):
+            mommy.make_many('core.Offer', quantity=2, price=10, issue=i)
+
+        for i in mommy.make_many('core.Issue', quantity=2, project__id=2, project__name='projectB'):
+            mommy.make_many('core.Offer', quantity=2, price=20, issue=i)
+
+        self.stats = stats_services.get_stats()
+
+    def test_projects(self):
+        qs = self.stats['projects']
+        self.assertQuerysetEqual(qs, [('projectB', 2, 80), ('projectA', 3, 60)],
+                             lambda p: (p.name, p.issue_count, p.offer_sum))

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -86,3 +86,23 @@ class SumPriceOfOpenOffers(TestCase):
     def test_sum_price_of_open_offers(self):
         self.assertEqual(99, self.stats['open_sum'])
 
+
+class SumPriceOfExpiredOffers(TestCase):
+    def setUp(self):
+        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=None)
+        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 12))
+        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 13))
+        mommy.make_one('core.Offer', status='PAID', price=1, expirationDate=date(2012, 12, 01))
+        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=None)
+        mommy.make_one('core.Offer', status='OPEN', price=1, expirationDate=date(2012, 12, 13))
+
+        # Query hits
+        mommy.make_one('core.Offer', status='OPEN', price=9, expirationDate=date(2012, 12, 01))
+        mommy.make_one('core.Offer', status='OPEN', price=90, expirationDate=date(2012, 12, 12))
+
+        with patch('django.utils.datetime_safe.date.today', Mock(return_value=date(2012, 12, 12))):
+            self.stats = stats_services.get_stats()
+
+    def test_sum_price_of_expired_offers(self):
+        self.assertEqual(99, self.stats['expired_sum'])
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -178,3 +178,5 @@ class CountOffers(TestCase):
     def test_count_open_offers(self):
         self.assertEqual(2, self.stats['open_offer_count'])
 
+    def test_count_revoked_offers(self):
+        self.assertEqual(2, self.stats['revoked_offer_count'])

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -121,3 +121,16 @@ class Sponsors(TestCase):
                                  lambda u: (u.screenName, u.paid_ammount, u.open_ammount))
 
 
+class CountSponsors(TestCase):
+    def setUp(self):
+        u1 = mommy.make_one('auth.User')
+        u2 = mommy.make_one('auth.User')
+        mommy.make_many('core.Offer', quantity=2, sponsor=u1)
+        mommy.make_many('core.Offer', quantity=2, sponsor=u2)
+
+        self.stats = stats_services.get_stats()
+
+    def test_count_sponsors(self):
+        self.assertEqual(2, self.stats['sponsor_count'])
+
+

--- a/djangoproject/core/tests/test_stats.py
+++ b/djangoproject/core/tests/test_stats.py
@@ -120,6 +120,12 @@ class Sponsors(TestCase):
         self.assertQuerysetEqual(qs, [('sponsorA', 10, 90)],
                                  lambda u: (u.screenName, u.paid_ammount, u.open_ammount))
 
+    def test_num_queries(self):
+        with self.assertNumQueries(1):
+            for obj in self.stats['sponsors']:
+                pass
+
+
 
 class CountSponsors(TestCase):
     def setUp(self):

--- a/djangoproject/core/urls.py
+++ b/djangoproject/core/urls.py
@@ -5,7 +5,7 @@ from django.conf import settings
 urlpatterns = patterns('core.views.main_views',
     url(r'^$', 'home'),
     url(r'^home/$', 'home'),
-    url(r'^stats/$', 'stats'),
+    url(r'^stats/$', 'stats', name='stats'),
     url(r'^admail/$', 'admail'),
     url(r'^about/$', TemplateView.as_view(template_name='core/about.html')),
     url(r'^faq/$', TemplateView.as_view(template_name='core/faq.html')),

--- a/djangoproject/templates/core/navbar.html
+++ b/djangoproject/templates/core/navbar.html
@@ -44,7 +44,7 @@
           </a>
           <div class="nav-collapse">
             <ul class="nav">
-              <li><a href="/core/stats">{% trans "Stats" %}</a></li>
+              <li><a href="{%  url stats %}">{% trans "Stats" %}</a></li>
               <li><a target="_about" href="http://blog.freedomsponsors.org/about">{% trans "About" %}</a></li>
               <li><a href="/core/feedback">{% trans "Feedback" %}</a></li>
               <li><a href="/core/issue">{% trans "Issues" %}</a></li>

--- a/djangoproject/templates/core/stats.html
+++ b/djangoproject/templates/core/stats.html
@@ -55,9 +55,9 @@
       </tr>
       {% for sponsor in stats.sponsors %}
       <tr>
-        <td><a href="/core/user/{{sponsor.0}}/{{sponsor.1}}">{{sponsor.1}}</td>
+        <td><a href="/core/user/{{sponsor.user.pk}}/{{sponsor.pk}}">{{sponsor.screenName}}</td>
         <td style="text-align:right">
-          {% include 'core/green_and_orange.html' with vOpen=sponsor.2 vPaid=sponsor.3 %}
+          {% include 'core/green_and_orange.html' with vOpen=sponsor.open_ammount vPaid=sponsor.paid_ammount %}
         </td>
       </tr>
       {% endfor %}

--- a/djangoproject/templates/core/stats.html
+++ b/djangoproject/templates/core/stats.html
@@ -35,9 +35,9 @@
       </tr>
       {% for project in stats.projects %}
       <tr>
-        <td><a href="/core/issue/?s=&project_id={{project.0}}">{{project.1}}</td>
-        <td style="text-align:right">{{project.2}}</td>
-        <td style="text-align:right">{{project.3}}</td>
+        <td><a href="/core/issue/?s=&project_id={{project.pk}}">{{project.name}}</td>
+        <td style="text-align:right">{{project.issue_count}}</td>
+        <td style="text-align:right">{{project.offer_sum}}</td>
       </tr>
       {% endfor %}
     </table>

--- a/djangoproject/templates/core/stats.html
+++ b/djangoproject/templates/core/stats.html
@@ -57,7 +57,7 @@
       <tr>
         <td><a href="/core/user/{{sponsor.user.pk}}/{{sponsor.pk}}">{{sponsor.screenName}}</td>
         <td style="text-align:right">
-          {% include 'core/green_and_orange.html' with vOpen=sponsor.open_ammount vPaid=sponsor.paid_ammount %}
+          {% include 'core/green_and_orange.html' with vOpen=sponsor.open_amount vPaid=sponsor.paid_amount %}
         </td>
       </tr>
       {% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dateutil==2.1
 six==1.2.0
 model-mommy==0.8.1
 mock==1.0.1
+django-aggregate-if==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ coverage==3.6b1
 python-dateutil==2.1
 six==1.2.0
 model-mommy==0.8.1
+mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ python-dateutil==2.1
 six==1.2.0
 model-mommy==0.8.1
 mock==1.0.1
-django-aggregate-if==0.3
+django-aggregate-if==0.3.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ python-dateutil==2.1
 six==1.2.0
 model-mommy==0.8.1
 mock==1.0.1
-django-aggregate-if==0.1
+django-aggregate-if==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ python-dateutil==2.1
 six==1.2.0
 model-mommy==0.8.1
 mock==1.0.1
-django-aggregate-if==0.2
+django-aggregate-if==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ simplejson==2.6.2
 coverage==3.6b1
 python-dateutil==2.1
 six==1.2.0
+model-mommy==0.8.1


### PR DESCRIPTION
This PR:
1. Eliminates custom SQLs for stats;
2. Reduces stats from 16 queries to 5. (middleware+stats are now 7 in total);
3. Adds tests for every stats data;
4. Uses [django-aggregate-if](pypi.python.org/pypi/django-aggregate-if/) to simplify queries;
