### PR TITLE
Refactor of home view

### DIFF
--- a/djangoproject/core/models.py
+++ b/djangoproject/core/models.py
@@ -232,6 +232,7 @@ class IssueManager(models.Manager):
         Always filter sponsoring OR kickstarting.
         '''
         qs = super(IssueManager, self).get_query_set()
+        qs = qs.filter(Q(is_feedback=False) | Q(offer__isnull=False)).distinct()
         qs = qs.filter(is_public_suggestion=self.is_kickstarting)
         return qs
 

--- a/djangoproject/core/tests/__init__.py
+++ b/djangoproject/core/tests/__init__.py
@@ -5,6 +5,7 @@ from test_payment_services import *
 from test_watch_services import *
 from test_watch_views import *
 from test_feedback_views import *
+from test_views_main import *
 
 __author__ = 'tony'
 

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -8,12 +8,15 @@ from model_mommy import mommy
 
 class HomeView(TestCase):
     def setUp(self):
-        # Sponsoring
+        # Feedback: pks from 1 to 11
+        mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=False, is_feedback=True, quantity=11)
+
+        # Sponsoring: pks from 12 to 22
         for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=False, quantity=11):
             mommy.make_one('core.Offer', issue=i, price=1, status='OPEN')
             mommy.make_one('core.Offer', issue=i, price=10, status='PAID')
 
-        # Kickstarting
+        # Kickstarting: pks from 23 to 33
         for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=True, quantity=11):
             mommy.make_one('core.Offer', issue=i, price=1, status='OPEN')
             mommy.make_one('core.Offer', issue=i, price=10, status='PAID')
@@ -36,14 +39,14 @@ class HomeView(TestCase):
 
     def test_issues_sponsoring(self):
         sponsoring = self.resp.context['issues_sponsoring']
-        expected = [(i, False, Decimal('1'), Decimal('10')) for i in range(1, 11)]
+        expected = [(i, False, Decimal('1'), Decimal('10')) for i in range(12, 22)]
 
         self.assertQuerysetEqual(sponsoring, expected,
                                  lambda i: (i.pk, i.is_public_suggestion, i.open_amount, i.paid_amount))
 
     def test_issues_kickstarting(self):
         sponsoring = self.resp.context['issues_kickstarting']
-        expected = [(i, True) for i in range(12, 22)]
+        expected = [(i, True) for i in range(23, 33)]
 
         self.assertQuerysetEqual(sponsoring, expected,
                                  lambda i: (i.pk, i.is_public_suggestion))

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,9 +1,20 @@
 # coding: utf-8
 from django.test import TestCase
+from model_mommy import mommy
 
 
 class HomeView(TestCase):
     def setUp(self):
+        # Sponsoring
+        for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=False, quantity=11):
+            mommy.make_one('core.Offer', issue=i, price=1, status='OPEN')
+            mommy.make_one('core.Offer', issue=i, price=10, status='PAID')
+
+        # Kickstarting
+        for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=True, quantity=11):
+            mommy.make_one('core.Offer', issue=i, price=1, status='OPEN')
+            mommy.make_one('core.Offer', issue=i, price=10, status='PAID')
+
         self.resp = self.client.get('/')
 
     def test_get(self):
@@ -15,4 +26,8 @@ class HomeView(TestCase):
     def test_context(self):
         self.assertIn('issues_sponsoring', self.resp.context)
         self.assertIn('issues_kickstarting', self.resp.context)
+
+    def test_num_queries(self):
+        with self.assertNumQueries(62):
+            self.client.get('/')
 

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from decimal import Decimal
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.core.urlresolvers import reverse as r
 from model_mommy import mommy
@@ -46,3 +47,13 @@ class HomeViewedByAnonymous(TestCase):
 
         self.assertQuerysetEqual(sponsoring, expected,
                                  lambda i: (i.pk, i.is_public_suggestion))
+
+
+class HomeViewedByUserWithoutProfile(TestCase):
+    def setUp(self):
+        User.objects.create_user('user', 'user@email.com', 'user')
+        assert self.client.login(username='user', password='user')
+        self.resp = self.client.get(r('home'))
+
+    def test_redirects(self):
+        self.assertRedirects(self.resp, '/core/user/edit?next=/')

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from decimal import Decimal
 from django.test import TestCase
 from model_mommy import mommy
 
@@ -31,3 +32,16 @@ class HomeView(TestCase):
         with self.assertNumQueries(62):
             self.client.get('/')
 
+    def test_issues_sponsoring(self):
+        sponsoring = self.resp.context['issues_sponsoring']
+        expected = [(i, False, Decimal('1'), Decimal('10')) for i in range(1, 11)]
+
+        self.assertQuerysetEqual(sponsoring, expected,
+                                 lambda i: (i.pk, i.is_public_suggestion, i.getTotalOffersPrice(), i.getTotalPaidPrice()))
+
+    def test_issues_kickstarting(self):
+        sponsoring = self.resp.context['issues_kickstarting']
+        expected = [(i, True) for i in range(12, 22)]
+
+        self.assertQuerysetEqual(sponsoring, expected,
+                                 lambda i: (i.pk, i.is_public_suggestion))

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -29,7 +29,7 @@ class HomeViewedByAnonymous(TestCase):
         self.assertIn('issues_kickstarting', self.resp.context)
 
     def test_num_queries(self):
-        with self.assertNumQueries(62):
+        with self.assertNumQueries(12):
             self.client.get('/')
 
     def test_issues_sponsoring(self):
@@ -37,7 +37,7 @@ class HomeViewedByAnonymous(TestCase):
         expected = [(i, False, Decimal('1'), Decimal('10')) for i in range(1, 11)]
 
         self.assertQuerysetEqual(sponsoring, expected,
-                                 lambda i: (i.pk, i.is_public_suggestion, i.getTotalOffersPrice(), i.getTotalPaidPrice()))
+                                 lambda i: (i.pk, i.is_public_suggestion, i.open_amount, i.paid_amount))
 
     def test_issues_kickstarting(self):
         sponsoring = self.resp.context['issues_kickstarting']

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from decimal import Decimal
 from django.test import TestCase
+from django.core.urlresolvers import reverse as r
 from model_mommy import mommy
 
 
@@ -16,7 +17,7 @@ class HomeViewedByAnonymous(TestCase):
             mommy.make_one('core.Offer', issue=i, price=1, status='OPEN')
             mommy.make_one('core.Offer', issue=i, price=10, status='PAID')
 
-        self.resp = self.client.get('/')
+        self.resp = self.client.get(r('home'))
 
     def test_get(self):
         self.assertEquals(200, self.resp.status_code)
@@ -30,7 +31,7 @@ class HomeViewedByAnonymous(TestCase):
 
     def test_num_queries(self):
         with self.assertNumQueries(2):
-            self.client.get('/')
+            self.client.get(r('home'))
 
     def test_issues_sponsoring(self):
         sponsoring = self.resp.context['issues_sponsoring']

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -1,1 +1,18 @@
 # coding: utf-8
+from django.test import TestCase
+
+
+class HomeView(TestCase):
+    def setUp(self):
+        self.resp = self.client.get('/')
+
+    def test_get(self):
+        self.assertEquals(200, self.resp.status_code)
+
+    def test_template(self):
+        self.assertTemplateUsed(self.resp, 'core/home.html')
+
+    def test_context(self):
+        self.assertIn('issues_sponsoring', self.resp.context)
+        self.assertIn('issues_kickstarting', self.resp.context)
+

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from model_mommy import mommy
 
 
-class HomeView(TestCase):
+class HomeViewedByAnonymous(TestCase):
     def setUp(self):
         # Sponsoring
         for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=False, quantity=11):

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -29,7 +29,7 @@ class HomeViewedByAnonymous(TestCase):
         self.assertIn('issues_kickstarting', self.resp.context)
 
     def test_num_queries(self):
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(2):
             self.client.get('/')
 
     def test_issues_sponsoring(self):

--- a/djangoproject/core/tests/test_views_main.py
+++ b/djangoproject/core/tests/test_views_main.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse as r
 from model_mommy import mommy
 
 
-class HomeViewedByAnonymous(TestCase):
+class HomeView(TestCase):
     def setUp(self):
         # Sponsoring
         for i in mommy.make_many('core.Issue', project__name='Linux', is_public_suggestion=False, quantity=11):

--- a/djangoproject/core/urls.py
+++ b/djangoproject/core/urls.py
@@ -3,8 +3,6 @@ from django.views.generic import TemplateView
 from django.conf import settings
 
 urlpatterns = patterns('core.views.main_views',
-    url(r'^$', 'home'),
-    url(r'^home/$', 'home'),
     url(r'^stats/$', 'stats'),
     url(r'^admail/$', 'admail'),
     url(r'^about/$', TemplateView.as_view(template_name='core/about.html')),

--- a/djangoproject/core/views/main_views.py
+++ b/djangoproject/core/views/main_views.py
@@ -60,7 +60,7 @@ def home(request):
     if(request.user.is_authenticated() and request.user.getUserInfo() == None):
         return redirect('/core/user/edit')
     issues_sponsoring = Issue.objects.filter(is_public_suggestion=False).select_related('project__name').annotate(paid_amount=Sum('offer__price', only=Q(offer__status='PAID')), open_amount=Sum('offer__price', only=Q(offer__status='OPEN'))).order_by('-updatedDate')[0:10]
-    issues_kickstarting = issue_services.search_issues(is_public_suggestion = True)[0:10]
+    issues_kickstarting = Issue.objects.filter(is_public_suggestion=True).select_related('project__name').order_by('-updatedDate')[0:10]
     return render_to_response('core/home.html',
         {'issues_sponsoring':issues_sponsoring,
          'issues_kickstarting':issues_kickstarting},

--- a/djangoproject/core/views/main_views.py
+++ b/djangoproject/core/views/main_views.py
@@ -55,9 +55,6 @@ def admail(request):
         context_instance = RequestContext(request))
 
 def home(request):
-    if(request.user.is_authenticated() and request.user.getUserInfo() == None):
-        return redirect('/core/user/edit')
-
     context = RequestContext(request, {
         'issues_sponsoring': Issue.sponsoring.recently_updated()[0:10],
         'issues_kickstarting': Issue.kickstarting.recently_updated()[0:10]

--- a/djangoproject/core/views/main_views.py
+++ b/djangoproject/core/views/main_views.py
@@ -1,5 +1,4 @@
-# Create your views here.
-
+# coding: utf-8
 from django.http import HttpResponseRedirect
 from django.contrib.auth import logout as auth_logout
 from django.template import  RequestContext
@@ -8,6 +7,9 @@ from core.services import issue_services
 from core.utils.frespo_utils import  dictOrEmpty
 from core.services.mail_services import *
 from core.services import stats_services
+from core.models import Issue
+from django.db.models import Q
+from aggregate_if import Sum
 from django.contrib import messages
 import logging
 
@@ -57,7 +59,7 @@ def admail(request):
 def home(request):
     if(request.user.is_authenticated() and request.user.getUserInfo() == None):
         return redirect('/core/user/edit')
-    issues_sponsoring = issue_services.search_issues(is_public_suggestion = False)[0:10]
+    issues_sponsoring = Issue.objects.filter(is_public_suggestion=False).select_related('project__name').annotate(paid_amount=Sum('offer__price', only=Q(offer__status='PAID')), open_amount=Sum('offer__price', only=Q(offer__status='OPEN'))).order_by('-updatedDate')[0:10]
     issues_kickstarting = issue_services.search_issues(is_public_suggestion = True)[0:10]
     return render_to_response('core/home.html',
         {'issues_sponsoring':issues_sponsoring,

--- a/djangoproject/core/views/main_views.py
+++ b/djangoproject/core/views/main_views.py
@@ -72,15 +72,3 @@ def stats(request):
     return render_to_response('core/stats.html',
         {'stats':stats,},
         context_instance = RequestContext(request))
-
-
-
-
-
-
-
-
-
-
-
-

--- a/djangoproject/templates/core/home.html
+++ b/djangoproject/templates/core/home.html
@@ -95,14 +95,14 @@
               <tr>
                 <td class="hometablecell" style="width:30px">{{forloop.counter}}.</td>
                 <td class="hometablecell" style="width:70px">
-                  {% include 'core/green_and_orange.html' with vOpen=issue.getTotalOffersPrice vPaid=issue.getTotalPaidPrice %}
+                  {% include 'core/green_and_orange.html' with vOpen=issue.open_amount vPaid=issue.paid_amount %}
                 </td>
                 <td class="hometablecell"><a href="{{issue.get_view_link}}"
-                  {% if issue.getTotalPaidPrice %}
+                  {% if issue.paid_amount %}
                    style="color:#090;"
                   {% endif %}
                  >
-                  {% if issue.getTotalPaidPrice %}
+                  {% if issue.paid_amount %}
                    <strong>PAID: </strong>
                   {% endif %}
                  {{issue}}</a></td>

--- a/djangoproject/templates/core/navbar.html
+++ b/djangoproject/templates/core/navbar.html
@@ -7,8 +7,8 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <!-- <a class="brand" href="/">FreedomSponsors.org<span style="font-size:13px"> (beta)</a> -->
-          <a class="brand" href="/" style="padding-top:0px;padding-bottom:0px;"><img id="upper_left_brand" src="/static/img/FS_name.png"></a>
+          <!-- <a class="brand" href="{% url home %}">FreedomSponsors.org<span style="font-size:13px"> (beta)</a> -->
+          <a class="brand" href="{% url home %}" style="padding-top:0px;padding-bottom:0px;"><img id="upper_left_brand" src="/static/img/FS_name.png"></a>
 {% if user and user.is_authenticated %}
           <div class="btn-group pull-right">
             <a id="a_userMenu" class="btn dropdown-toggle" data-toggle="dropdown" href="#">


### PR DESCRIPTION
This PR simplifies the `home` view implementing a new proposal about how to deal with complex queries.

The `home` view is a very simple one, or it should be. Yet, it generates **62 queries** to list _10 sponsoring_ issues and _10 kickstarting_ issues.

The main problem is how FS relies on it's models.
- FS models are not using the [RelatedManagers](https://docs.djangoproject.com/en/dev/ref/models/relations/) automatically generated by the framework. This ends up generating many queries instead of using joins to  retrieve related informations.
- Many of the current existing methods implemented by FS models should be in Custom Managers. 

What was done:
1. Reduced from 62 queries to 2.
2. Extracted query complexity to the custom manager IssueManager.
3. Used [url name](https://docs.djangoproject.com/en/dev/topics/http/urls/#naming-url-patterns) to avoid hardcoded urls.
4. Cleanedup unreachable code.
