### PR TITLE
Add a feed to /core/issue in /core/issue/rss.

### DIFF
--- a/djangoproject/core/urls.py
+++ b/djangoproject/core/urls.py
@@ -18,6 +18,7 @@ urlpatterns += patterns('core.views.issue_views',
     url(r'^project/$', 'listProjects'),
     url(r'^myissues/$', 'myissues'),
     url(r'^issue/$', 'listIssues'),
+    url(r'^issue/rss$', 'listIssuesFeed'),
     url(r'^issue/sponsor/submit$', 'sponsorIssue'),
     url(r'^issue/sponsor$', 'addIssueForm'),
     url(r'^issue/add/submit$', 'addIssue'),
@@ -80,5 +81,4 @@ urlpatterns += patterns('core.views.feedback_views',
     url(r'^feedback$', 'feedback'),
     url(r'^feedback/submit$', 'addFeedback'),
 )
-
 


### PR DESCRIPTION
It is a really simple feed, but it can help people follow lastest issues (see #61).

You can filter exactly like issues page, so `/core/issue/rss?project_name=www.freedomsponsors.org` works. Query strings `project_id` and `s` (for search string) works too.
