### PR TITLE
Move the kickstart help outside the button.

### DIFF
--- a/djangoproject/templates/core/home.html
+++ b/djangoproject/templates/core/home.html
@@ -23,10 +23,9 @@
         <label>{% trans "Issue URL" %}</label>
         <input type="text" name="trackerURL" id="trackerURL" class="input-xlarge" placeholder="{% trans 'Paste the issue URL' %}">
         <input type="hidden" name="operation" id="operation">
-        <button id="btnKickstart" class="btn btn-primary ">{% trans "Kickstart &gt;&gt;" %}
-          <i class="icon-question-sign icon-white popopo_stay" rel="popover" data-content="Create an issue without an offer, just to draw everyone's attention to it. See more in <a href='http://blog.freedomsponsors.org/kickstarting-issues/'>the blog</a>!" data-original-title="What's this?"></i>
-        </button> 
         <button id="btnSponsor" class="btn btn-primary ">{% trans "Sponsor &gt;&gt;" %}</button>
+        <a id="btnKickstart" class="btn">{% trans "Kickstart &gt;&gt;" %}</a>
+        <i class="icon-question-sign icon-black popopo_stay" style="margin-top:3px;" rel="popover" data-content="Create an issue without an offer, just to draw everyone's attention to it. <a href='http://blog.freedomsponsors.org/kickstarting-issues/'>See more in the blog</a>!" data-original-title="What's kickstart?" data-placement="bottom"></i>
         <div class="btn-toolbar">
           <div class="btn-group pull-right">
           </div>


### PR DESCRIPTION
Make kickstart button a secondary action.
Set popover help placement to bottom, so popover does not hide the kickstart button.

These actions make the interface cleaner, with only one primary action.

It fixes #131 and is related with #123.

![frespo_kickstart_popover](https://f.cloud.github.com/assets/105852/84571/7d9c9bbc-6418-11e2-9db0-bb9753da2250.png)

![frespo_kickstart_popover_open](https://f.cloud.github.com/assets/105852/84573/ac8d1a6e-6418-11e2-9c9b-1f5cd15cfb53.png)
