### PR TITLE
Added a link in projects page to search related sponsors

### DIFF
--- a/djangoproject/core/models.py
+++ b/djangoproject/core/models.py
@@ -250,6 +250,9 @@ class Project(models.Model):
         project.trackerURL = trackerURL
         return project
 
+    def get_view_link(self):
+        return '/core/issue/?s=&project_id=%s&project_name=%s' % (self.id,urlquote(self.name),)
+
     def __unicode__(self):
         return self.name
     

--- a/djangoproject/core/static/css/frespo.css
+++ b/djangoproject/core/static/css/frespo.css
@@ -115,5 +115,15 @@ font-size: 14px;
   background-color:#b0e0e6;
 }
 
+table.projects .project-name, table.projects a.project-sponsors  {
+  display: block;
+  float: left;
+}
+table.projects  a.project-sponsors {
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAVklEQVR4Xn3PgQkAMQhDUXfqTu7kTtkpd5RA8AInfArtQ2iRXFWT2QedAfttj2FsPIOE1eCOlEuoWWjgzYaB/IkeGOrxXhqB+uA9Bfcm0lAZuh+YIeAD+cAqSz4kCMUAAAAASUVORK5CYII=") no-repeat scroll right center transparent;
+  padding-right: 13px;
+  display: block;
+  text-indent: -999em;
+}
 /*** Gregorio Benatti */
 

--- a/djangoproject/templates/core/project_list.html
+++ b/djangoproject/templates/core/project_list.html
@@ -1,5 +1,5 @@
 {% extends "core/base.html" %}
-
+{% load i18n %}
 {% block mainContent%}
 
 {% if projects %}
@@ -7,7 +7,7 @@
 <h3>Projects</h3>
 <span style="font-size:12px">To add a project, <a href="/core/issue/add">sponsor</a> a new Issue</span>
 <hr>
-<table class="table table-condensed table-striped">
+<table class="table table-condensed table-striped projects">
   <thead>
     <tr>
       <th>Project</th>
@@ -19,7 +19,7 @@
 {% autopaginate projects 50 %}
 {% for project in projects %}
     <tr>
-      <td>{{ project.name }}</td>
+      <td ><span class="project-name">{{ project.name }}</span><a href="{{project.get_view_link}}" title="{% trans 'Browser sponsors' %}" class="project-sponsors">{% trans "Browser sponsors" %}</a></td>
       <td><a href="{{ project.homeURL }}" target="_project">{{ project.homeURL }}</a></td>
       <td><a href="{{ project.trackerURL }}" target="_tracker">{{ project.trackerURL }}</a></td>
     </tr>


### PR DESCRIPTION
I think it was missing something like that, so the users could find  project tasks more quickly.
