### PR TITLE
Correct rednose dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ six==1.2.0
 Unipath==0.2.1
 dj-database-url==0.2.1
 django-nose==1.1
-rednose==0.3.3
+rednose==0.3
 httplib2==0.7.7
 django-social-auth==0.7.20
 requests==0.14.1


### PR DESCRIPTION
I had trouble installing freedomsponsors from scratch. It failed at the bootstrap phase because the version 0.3.3 version of rednose doesn't seem to exist under that number anymore. Using 0.3 seems to work fine
