### PR TITLE
Remove `/core` from watch issues/offers to simplify routes.

### DIFF
--- a/djangoproject/core/tests/test_mail_notifications.py
+++ b/djangoproject/core/tests/test_mail_notifications.py
@@ -3,6 +3,7 @@ from django.utils import unittest
 from core.services import watch_services
 from helpers import test_data, email_asserts
 from django.test.client import Client
+from django.core.urlresolvers import reverse
 
 __author__ = 'tony'
 
@@ -16,9 +17,9 @@ class TestMailNotifications(unittest.TestCase):
     def test_should_send_mail_for_new_comments(self):
         offer = test_data.create_dummy_offer_usd()
         issue = offer.issue
-        response = self.client.get('/core/watch/issue/%s'%issue.id)
+        response = self.client.get(reverse('core.views.watch_views.watchIssue', kwargs={'issue_id': issue.id }))
         self.assertEqual(response.status_code, 200)
-        response = self.client.get('/core/watch/offer/%s'%offer.id)
+        response = self.client.get(reverse('core.views.watch_views.watchOffer', kwargs={'offer_id': offer.id }))
         self.assertEqual(response.status_code, 200)
 
         user2 = test_data.createDummyUserRandom(login='marydoe', password='xyz456')
@@ -42,7 +43,7 @@ class TestMailNotifications(unittest.TestCase):
     def test_should_send_mail_for_adding_or_changing_or_revoking_offer(self):
         offer = test_data.create_dummy_offer_usd()
         issue = offer.issue
-        response = self.client.get('/core/watch/issue/%s'%issue.id)
+        response = self.client.get(reverse('core.views.watch_views.watchIssue', kwargs={'issue_id': issue.id }))
         self.assertEqual(response.status_code, 200)
 
         user2 = test_data.createDummyUserRandom(login='marydoe', password='xyz456')
@@ -83,7 +84,7 @@ class TestMailNotifications(unittest.TestCase):
     def test_should_send_mail_for_starting_or_aborting_or_finishing_work(self):
         offer = test_data.create_dummy_offer_usd()
         issue = offer.issue
-        response = self.client.get('/core/watch/issue/%s'%issue.id)
+        response = self.client.get(reverse('core.views.watch_views.watchIssue', kwargs={'issue_id': issue.id }))
         self.assertEqual(response.status_code, 200)
 
         user2 = test_data.createDummyUserRandom(login='marydoe', password='xyz456')

--- a/djangoproject/core/tests/test_watch_views.py
+++ b/djangoproject/core/tests/test_watch_views.py
@@ -1,11 +1,15 @@
-from django.utils import unittest
+from django.test import TestCase
 from core.services import watch_services
-from helpers import test_data, email_asserts
+from helpers import test_data
 from django.test.client import Client
+from django.core.urlresolvers import reverse
 
 __author__ = 'tony'
 
-class TestWatchViews(unittest.TestCase):
+def _reverse(watch_view, **kwargs):
+    return reverse('core.views.watch_views.' + watch_view, kwargs=kwargs)
+
+class TestWatchViews(TestCase):
     def setUp(self):
         # Every test needs a client.
         self.user = test_data.createDummyUserRandom(login='johndoe', password='abc123')
@@ -16,12 +20,12 @@ class TestWatchViews(unittest.TestCase):
         issue = test_data.create_dummy_issue()
         self.assertTrue(not watch_services.is_watching_issue(self.user, issue.id))
 
-        response = self.client.get('/core/watch/issue/%s'%issue.id)
+        response = self.client.get(_reverse('watchIssue', issue_id=issue.id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, 'WATCHING')
         self.assertTrue(watch_services.is_watching_issue(self.user, issue.id))
 
-        response = self.client.get('/core/unwatch/issue/%s'%issue.id)
+        response = self.client.get(_reverse('unwatchIssue', issue_id=issue.id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, 'NOT_WATCHING')
         self.assertTrue(not watch_services.is_watching_issue(self.user, issue.id))
@@ -30,13 +34,44 @@ class TestWatchViews(unittest.TestCase):
         offer = test_data.create_dummy_offer_usd()
         self.assertTrue(not watch_services.is_watching_offer(self.user, offer.id))
 
-        response = self.client.get('/core/watch/offer/%s'%offer.id)
+        response = self.client.get(_reverse('watchOffer', offer_id=offer.id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, 'WATCHING')
         self.assertTrue(watch_services.is_watching_offer(self.user, offer.id))
 
-        response = self.client.get('/core/unwatch/offer/%s'%offer.id)
+        response = self.client.get(_reverse('unwatchOffer', offer_id=offer.id))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, 'NOT_WATCHING')
         self.assertTrue(not watch_services.is_watching_offer(self.user, offer.id))
 
+
+class TestDeprecatedCoreWatchViews(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def assert_permanent_redirect(self, expected_url, deprecated_url, status_code=301):
+        response = self.client.get(deprecated_url)
+        location = response._headers['location'][1]
+        self.assertTrue(location.endswith(expected_url))
+        self.assertEqual(response.status_code, status_code)
+
+    def test_watch_issue(self):
+        issue = test_data.create_dummy_issue()
+        self.assert_permanent_redirect(_reverse('watchIssue', issue_id=issue.id),
+            '/core/watch/issue/%s' % issue.id)
+
+    def test_unwatch_issue(self):
+        issue = test_data.create_dummy_issue()
+        self.assert_permanent_redirect(_reverse('unwatchIssue', issue_id=issue.id),
+            '/core/unwatch/issue/%s' % issue.id)
+
+    def test_watch_offer(self):
+        offer = test_data.create_dummy_offer_usd()
+        self.assert_permanent_redirect(_reverse('watchOffer', offer_id=offer.id),
+            '/core/watch/offer/%s' % offer.id)
+
+    def test_unwatch_offer(self):
+        offer = test_data.create_dummy_offer_usd()
+        self.assert_permanent_redirect(_reverse('unwatchOffer', offer_id=offer.id),
+            '/core/unwatch/offer/%s' % offer.id)

--- a/djangoproject/core/urls/__init__.py
+++ b/djangoproject/core/urls/__init__.py
@@ -1,5 +1,5 @@
 from django.conf.urls import patterns, include, url
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 from django.conf import settings
 from django.views.generic.simple import redirect_to
 
@@ -55,11 +55,11 @@ urlpatterns += patterns('core.views.comment_views',
     url(r'^offer/comment/(?P<comment_id>\d+)/history$', 'viewOfferCommentHistory'),
 )
 
-urlpatterns += patterns('core.views.watch_views',
-    url(r'^watch/issue/(?P<issue_id>\d+)$', 'watchIssue'),
-    url(r'^unwatch/issue/(?P<issue_id>\d+)$', 'unwatchIssue'),
-    url(r'^watch/offer/(?P<offer_id>\d+)$', 'watchOffer'),
-    url(r'^unwatch/offer/(?P<offer_id>\d+)$', 'unwatchOffer'),
+urlpatterns += patterns('', # TODO: how to use reverse_lazy here?
+    url(r'^watch/issue/(?P<issue_id>\d+)$', RedirectView.as_view(url='/issue/%(issue_id)s/watch', permanent=True)),
+    url(r'^unwatch/issue/(?P<issue_id>\d+)$', RedirectView.as_view(url='/issue/%(issue_id)s/unwatch', permanent=True)),
+    url(r'^watch/offer/(?P<offer_id>\d+)$', RedirectView.as_view(url='/offer/%(offer_id)s/watch', permanent=True)),
+    url(r'^unwatch/offer/(?P<offer_id>\d+)$', RedirectView.as_view(url='/offer/%(offer_id)s/unwatch', permanent=True)),
 )
 
 urlpatterns += patterns('core.views.paypal_views',

--- a/djangoproject/core/urls/watch_urls.py
+++ b/djangoproject/core/urls/watch_urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns('core.views.watch_views',
+    url(r'^issue/(?P<issue_id>\d+)/watch$', 'watchIssue'),
+    url(r'^issue/(?P<issue_id>\d+)/unwatch$', 'unwatchIssue'),
+    url(r'^offer/(?P<offer_id>\d+)/watch$', 'watchOffer'),
+    url(r'^offer/(?P<offer_id>\d+)/unwatch$', 'unwatchOffer'),
+)
+

--- a/djangoproject/frespo/urls.py
+++ b/djangoproject/frespo/urls.py
@@ -3,6 +3,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 # TODO: remove core dependency
 from core.forms import RegistrationForm
+from core.urls import watch_urls
 
 admin.autodiscover()
 
@@ -26,6 +27,8 @@ urlpatterns = patterns('',
         name='emailmgr_email_activate'
     ),
 )
+
+urlpatterns += watch_urls.urlpatterns
 
 urlpatterns += staticfiles_urlpatterns()
 # urlpatterns += feedback_urlpatterns


### PR DESCRIPTION
I moved routes like `/core/watch/issue/<id>` to `/issue/<id>/watch`.

It is a bit more than just remove the `/core`, but I used this change to separate the action from the object. I'm executing the `watch` action in `issue <id>`.

These changes are equivalent to `unwatch` action and to `offers`
