### PR TITLE
Move /core/project/* routes to /project/*

### DIFF
--- a/djangoproject/core/tests/test_project_views.py
+++ b/djangoproject/core/tests/test_project_views.py
@@ -1,0 +1,75 @@
+from StringIO import StringIO
+
+import mock
+from django.test import TestCase
+from helpers import test_data
+from django.test.client import Client
+from django.core.urlresolvers import reverse, resolve
+from django.conf import settings
+
+
+__author__ = 'tony'
+
+
+def _reverse(project_view, **kwargs):
+    return reverse('core.views.project_views.' + project_view, kwargs=kwargs)
+
+
+class TestProjectViews(TestCase):
+
+    def setUp(self):
+        self.project = test_data.create_dummy_project()
+        self.client = Client()
+
+    def test_project_list(self):
+        response = self.client.get(_reverse('list'))
+        self.assertTemplateUsed(response, 'core2/project_list.html')
+        projects = response.context['projects']
+        self.assertEqual('Hibernate', projects[0].name)
+
+    def test_project_view(self):
+        response = self.client.get(_reverse('view', project_id=self.project.id))
+        self.assertTemplateUsed(response, 'core2/project.html')
+        project = response.context['project']
+        self.assertEqual('Hibernate', project.name)
+
+    def test_project_edit_form(self):
+        response = self.client.get(_reverse('edit_form', project_id=self.project.id))
+        self.assertTemplateUsed(response, 'core2/project_edit.html')
+        project = response.context['project']
+        self.assertEqual('Hibernate', project.name)
+
+    def test_project_edit(self):
+        file_obj = StringIO()
+        setattr(file_obj, 'name', 'mock.jpg')
+        with mock.patch.object(self.project, 'save') as _save:
+            response = self.client.post(_reverse('edit'),
+                                        {'id': self.project.id, 'image3x1': file_obj})
+            self.assertTrue(_save.has_been_called())
+        location = response._headers['location'][1]
+        self.assertTrue(location.endswith(_reverse('view', project_id=self.project.id)))
+
+
+class TestDeprecatedCoreProjectViews(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def assert_permanent_redirect(self, expected_url, deprecated_url, status_code=301):
+        response = self.client.get(deprecated_url)
+        self.assertEqual(response.status_code, status_code)
+        location = response._headers['location'][1]
+        self.assertTrue(location.endswith(expected_url))
+
+    def test_project_list(self):
+        self.assert_permanent_redirect(_reverse('list'), '/core/project/')
+
+    def test_project_view(self):
+        project = test_data.create_dummy_project()
+        self.assert_permanent_redirect(_reverse('view', project_id=project.id),
+            '/core/project/%s/' % project.id)
+
+    def test_project_edit_form(self):
+        project = test_data.create_dummy_project()
+        self.assert_permanent_redirect(_reverse('edit_form', project_id=project.id),
+            '/core/project/%s/edit' % project.id)

--- a/djangoproject/core/urls/__init__.py
+++ b/djangoproject/core/urls/__init__.py
@@ -41,11 +41,10 @@ urlpatterns += patterns('core.views.issue_views',
     url(r'^solution/resolve/submit$', 'resolveSolution'),
 )
 
-urlpatterns += patterns('core.views.project_views',
-    url(r'^project/$', 'list'),
-    url(r'^project/(?P<project_id>\d+)/$', 'view'),
-    url(r'^project/(?P<project_id>\d+)/edit$', 'edit_form'),
-    url(r'^project/submit$', 'edit'),
+urlpatterns += patterns('',
+    url(r'^project/$', RedirectView.as_view(url='/project/', permanent=True)),
+    url(r'^project/(?P<project_id>\d+)/$', RedirectView.as_view(url='/project/%(project_id)s/', permanent=True)),
+    url(r'^project/(?P<project_id>\d+)/edit$', RedirectView.as_view(url='/project/%(project_id)s/edit', permanent=True)),
 )
 
 urlpatterns += patterns('core.views.comment_views',

--- a/djangoproject/core/urls/project_urls.py
+++ b/djangoproject/core/urls/project_urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns('core.views.project_views',
+    url(r'^$', 'list'),
+    url(r'^(?P<project_id>\d+)/$', 'view'),
+    url(r'^(?P<project_id>\d+)/edit$', 'edit_form'),
+    url(r'^submit$', 'edit'),
+)

--- a/djangoproject/core/views/project_views.py
+++ b/djangoproject/core/views/project_views.py
@@ -26,7 +26,7 @@ def edit(request):
     if 'image3x1' in request.FILES and request.FILES['image3x1']:
         project.image3x1 = request.FILES['image3x1']
         project.save()
-    return redirect('/core/project/%s' % project.id)
+    return redirect('core.views.project_views.view', project_id=project.id)
 
 
 def list(request):

--- a/djangoproject/frespo/urls.py
+++ b/djangoproject/frespo/urls.py
@@ -15,6 +15,7 @@ if 'core' in settings.INSTALLED_APPS:
         url(r'^$', 'core.views.main_views.home', name='home'),
         url(r'^faq$', direct_to_template, {'template': 'core2/faq.html'}),
         url(r'^core/', include('core.urls')),
+        url(r'^project/', include('core.urls.project_urls')),
         url(r'^sandbox/', include('sandbox.urls')),
         url(r'^github/', include('gh_frespo_integration.urls')),
         url(r'^bladmin/doc/', include('django.contrib.admindocs.urls')),

--- a/djangoproject/templates/core2/project.html
+++ b/djangoproject/templates/core2/project.html
@@ -5,5 +5,5 @@
 {% block mainContent%}
     <h2> project: {{ project.name }}</h2>
     <img src="{{ project.get_image3x1 }}">
-    <a href="/core/project/{{ project.id }}/edit">Edit</a>
+    <a href="{% url core.views.project_views.edit_form project_id=project.id %}">Edit</a>
 {% endblock mainContent%}

--- a/djangoproject/templates/core2/project_edit.html
+++ b/djangoproject/templates/core2/project_edit.html
@@ -5,7 +5,7 @@
 {% block mainContent%}
     <h2> Editing project: {{ project.name }}</h2>
     <hr>
-    <form method="POST" action="/core/project/submit" enctype="multipart/form-data">
+    <form method="POST" action="{% url core.views.project_views.edit %}" enctype="multipart/form-data">
         {% csrf_token %}
         <input type="hidden" name="id" value="{{ project.id }}">
         <div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ git+git://github.com/freedomsponsors/python-paypalx.git@34d624ed8a7b6505aa6e6e12
 django-registration==0.8
 django-emailmgr==0.9
 PIL==1.1.7
+mock==1.0.1


### PR DESCRIPTION
Deprecated routes redirected 301 to new routes.
Tests added to all project routes, including all redirects.

It is part of #128.
