### PR TITLE
URL to sponsors does not work. #265

### DIFF
--- a/djangoproject/templates/core2/issue.html
+++ b/djangoproject/templates/core2/issue.html
@@ -215,6 +215,17 @@
 
 
         }
+
+        function activaTab(tab){
+            $('a[href="' + tab + '"]').trigger('click');
+        };
+
+        $(document).ready(function(){
+            var h = document.location.hash;
+            if(h) {
+                activaTab(h);
+            }
+        });
     </script>
 {% endblock %}
 


### PR DESCRIPTION
 parse document.location.hash to activate specific tab
