### PR TITLE
Proporse info box - text unreadable. #281

### DIFF
--- a/djangoproject/statfiles/static/css2/freedom_bootstrap.css
+++ b/djangoproject/statfiles/static/css2/freedom_bootstrap.css
@@ -3742,7 +3742,7 @@
 #bootstrap-content .popover-title {
   padding: 9px 15px;
   line-height: 1;
-  background-color: #f5f5f5;
+  background-color: #ada6a6;
   border-bottom: 1px solid #eee;
   -webkit-border-radius: 3px 3px 0 0;
   -moz-border-radius: 3px 3px 0 0;
@@ -3751,6 +3751,7 @@
 #bootstrap-content .popover-content {
   padding: 14px;
   background-color: #ffffff;
+  color: #9e9898;
   -webkit-border-radius: 0 0 3px 3px;
   -moz-border-radius: 0 0 3px 3px;
   border-radius: 0 0 3px 3px;


### PR DESCRIPTION
It seems fixed by tuning CSS color values.

I am not really confident in my CSS knowledge and taste in colors, but it is more readable with the fix.

![iss281_popup_text](https://cloud.githubusercontent.com/assets/1835678/4430409/db743de6-462d-11e4-852e-875052f75eec.png)
